### PR TITLE
restrict lodash to version 3.x.x, version 4.x breaks wiredep

### DIFF
--- a/generators/common/templates/package.json
+++ b/generators/common/templates/package.json
@@ -16,7 +16,7 @@
     "grunt-wiredep": "^1.9.0",
     "jshint-stylish": "^0.4.0",
     "load-grunt-tasks": "^0.6.0",
-    "lodash": ">3.0"
+    "lodash": "^3.0"
   },
   "engines": {
     "node": ">= 0.10.0"


### PR DESCRIPTION
With the current package.json in a newly generated app, lodash v4.5.0 is installed. This breaks the wiredep task:

```
Running "araport-wiredep" task
Wiring dependencies from araport-app.json
for filetype: js
Warning: $._(...).forEach(...).value is not a function Use --force to continue.

Aborted due to warnings.
```

It looks like lodash v4 came out about a month ago  with lots of breaking changes.
